### PR TITLE
Add functional contextualist roadmap for PUMA architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,3 +96,11 @@ The system incorporates core knowledge priors that mirror human reasoning:
 5. **Curriculum Learning**: Progressive difficulty training
 
 This architecture provides a strong foundation for achieving the 85% accuracy target on ARC-AGI-2 while staying within Kaggle's compute constraints.
+
+## Functional Contextualist Extension
+
+The complementary behavioral roadmap described in
+[`functional_contextualist_architecture.md`](functional_contextualist_architecture.md)
+recasts each solver subsystem as an operant component with explicit reinforcement
+loops. Refer to that document for the integration plan covering the proposed
+`BehavioralEngine`, tacting extensions, and RFT-driven relational inference.

--- a/docs/functional_contextualist_architecture.md
+++ b/docs/functional_contextualist_architecture.md
@@ -1,0 +1,96 @@
+[S:DOC v1] doc=functional_contextualist_architecture sections=5 scope=behavioral pass
+
+# A Functional Contextualist Architecture for Abstract Reasoning: Integrating Behavioral Analysis into the PUMA Solver
+
+## 1. Architectural Analysis of PUMA as a Behavioral System
+
+### 1.1 Neuroscience-Inspired Foundations
+- **Multiple-Demand (MD) Network Analog** — `arc_solver/neural/guidance.py`
+- **Basal Ganglia Gating Analog** — `arc_solver/enhanced_search.py`
+- **Hippocampal–mPFC Loop Analog** — `arc_solver/neural/episodic.py`
+- **Test-Time Adaptation Analog** — `arc_solver/ttt.py`
+
+### 1.2 Behavioral Deconstruction (A–B–C Model)
+| Element | PUMA Realisation | Notes |
+| --- | --- | --- |
+| Antecedent Stimulus | ARC task grids (`data/arc-agi_training_challenges.json`) | Input demonstrations/tables |
+| Behavior (Operant) | Synthesised DSL program (`arc_solver/dsl.py`, `arc_solver/dsl_complete.py`) | Candidate solutions |
+| Consequence | Correctness evaluation (`evaluate_performance.py`) | Reward signal |
+
+**Stimulus Control:** NeuralGuidance adapts operation probabilities from features (`arc_solver/features.py`).
+
+**Learning History:** EpisodicRetrieval stores reinforced program traces (`episodes.json`).
+
+### 1.3 Review of Relational Modules
+- `arc_solver/object_reasoning.py` provides object descriptors.
+- `arc_solver/human_reasoning.py` encodes static geometric relations.
+- Current system lacks operant relational learning — relations are hand-engineered rather than learned frames.
+
+## 2. Re-Imagining the DSL as Verbal Behavior
+
+### 2.1 Skinnerian Foundations
+- **Tacts:** Labeling environmental stimuli.
+- **Intraverbals:** Chains of verbal responses controlled by preceding responses.
+- **Mands:** Responses motivated by establishing operations.
+
+### 2.2 Tacting Module Proposal
+- Extend features/objects to produce learned symbolic descriptors.
+- Reinforce tact emission when associated programs solve tasks.
+
+### 2.3 Intraverbal Chaining for Program Synthesis
+- Treat program generation as conditional probability chain `P(op_n | grid_{n-1}, tacts)`.
+- Allow shaping via progressive reinforcement on partial programs.
+
+### 2.4 Behavioral Mapping Table
+| Behavioral Concept | Module | Function |
+| --- | --- | --- |
+| Antecedent Stimulus | ARC task input | Evokes behavior |
+| Behavior / Operant | DSL program | Acts on environment |
+| Consequence | Grader output | Reinforcement |
+| Reinforcement Mechanism | Proposed BehavioralEngine | Reward delivery |
+| Stimulus Control | NeuralGuidance | Probability shaping |
+| Learning History | EpisodicRetrieval | Memory of reinforced behaviors |
+| Tacting | Proposed module atop `arc_solver/features.py` | Descriptive labeling |
+| Intraverbal Behavior | Enhanced search with chaining | Sequenced operations |
+| Relational Framing | Proposed RFTEngine | Derived relations |
+
+## 3. Engineering an RFT Engine for Novel Problem-Solving
+
+### 3.1 Multiple Exemplar Training
+- Mine relational patterns across solved tasks using object-centric state.
+
+### 3.2 Derived Relational Responding
+- Maintain relational graph with mutual/combinatorial entailment rules.
+
+### 3.3 Transformation of Stimulus Functions
+- Treat DSL applicability as stimulus functions.
+- Transfer functions across derived equivalent stimuli to generalise behavior.
+
+## 4. Implementation Roadmap
+
+### 4.1 BehavioralEngine
+- Online training loop orchestrating solver invocations.
+- Reward grader producing continuous feedback `[0.0, 1.0]`.
+- Broadcast reinforcement signals to adaptive modules.
+
+### 4.2 Module Adaptations
+- **NeuralGuidance:** Online updates from rewards.
+- **EpisodicRetrieval:** Track average reward per program.
+- **EnhancedSearch:** Prioritise high-reward guidance/memory suggestions.
+
+### 4.3 Agentic Integration
+- Embed RFT state into agentic solver observation space (`docs/AGENTIC_GENOMIC_SOLVER.md`).
+- Use RL loop with structured rewards for intermediate progress.
+
+## 5. Anticipated Capabilities and Future Work
+
+### 5.1 Novel Problem-Solving
+- Generalise via relational frames.
+- Encourage creative intraverbal chaining.
+
+### 5.2 Functional Contextualism in AI
+- Emphasises behavior shaped by consequences over static knowledge.
+
+### 5.3 Future Research
+- Explore deictic framing (I/You, Here/There, Now/Then).
+- Investigate self-modeling using extended RFT principles.


### PR DESCRIPTION
## Summary
- add a dedicated documentation page describing the functional contextualist/RFT roadmap for PUMA, including reinforcement-focused modules and behavioral mappings
- link the core architecture overview to the new roadmap for discoverability

## Testing
- PYTHONPATH=. pytest tests/test_agentic_small.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cdea7b6bd08322acd52923a0bc6c3d