### PR TITLE
Implement behavioral reinforcement engine with RFT integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ python tools/train_guidance.py
 python tools/benchmark.py
 ```
 
+### Operant Behavioral Training
+
+```bash
+# Enable the behavioural loop (feature-flagged for safety)
+export PUMA_BEHAVIORAL_ENGINE=1
+
+# Run reinforcement training with default dataset paths
+python -c "from pathlib import Path;\
+from arc_solver.behavioral_engine import BehavioralEngine;\
+engine = BehavioralEngine();\
+engine.train(Path('data/arc-agi_training_challenges.json'), Path('data/arc-agi_training_solutions.json'), max_tasks=10)"
+```
+
+The command above executes the production `BehavioralEngine`, emitting structured
+JSON logs with reward metrics while updating neural guidance and episodic memory
+online. Unset `PUMA_BEHAVIORAL_ENGINE` to leave runtime behaviour unchanged.
+
 ### Python API
 
 ```python

--- a/arc_solver/behavioral_engine.py
+++ b/arc_solver/behavioral_engine.py
@@ -1,0 +1,340 @@
+"""Reinforcement-oriented training loop for the ARC solver.
+
+This module implements the behavioural control loop outlined in the
+functional contextualist roadmap.  It provides a production-grade
+training orchestrator that presents ARC tasks as antecedents, executes
+behaviours (program synthesis attempts), and propagates consequences as
+reinforcement updates to neural guidance and episodic memory modules.
+
+The engine is intentionally deterministic and side-effect free unless
+explicitly enabled via the ``PUMA_BEHAVIORAL_ENGINE`` feature flag to
+guarantee safe rollouts inside evaluation pipelines.
+
+[S:DESIGN v1] approach=behavioural_engine+reward_grader alt={offline_supervised,policy_gradient_rl} reason=online-reinforcement pass
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+from pathlib import Path
+import random
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .dsl import apply_program
+from .enhanced_search import EnhancedSearch
+from .grid import Array
+from .neural.guidance import NeuralGuidance
+from .neural.episodic import EpisodicRetrieval
+from .rft_engine.engine import RFTEngine, RFTInference
+from .utils.metrics import MovingAverage
+
+
+TrainPair = Tuple[Array, Array]
+Program = List[Tuple[str, Dict[str, Any]]]
+
+
+class FeatureToggle:
+    """Environment-backed feature toggle with safe default off."""
+
+    def __init__(self, env_var: str = "PUMA_BEHAVIORAL_ENGINE") -> None:
+        self.env_var = env_var
+
+    @property
+    def enabled(self) -> bool:
+        value = os.environ.get(self.env_var, "0").strip().lower()
+        return value in {"1", "true", "on", "yes"}
+
+
+@dataclass
+class RewardBreakdown:
+    """Detailed reinforcement signal produced by :class:`RewardGrader`."""
+
+    pixel_accuracy: float
+    shape_accuracy: float
+    behaviour_bonus: float
+    program_length_penalty: float
+    reward: float
+
+
+class RewardGrader:
+    """Compute scalar rewards with interpretable sub-metrics."""
+
+    def __init__(
+        self,
+        pixel_weight: float = 0.7,
+        shape_weight: float = 0.2,
+        behaviour_weight: float = 0.1,
+        length_penalty: float = 0.02,
+    ) -> None:
+        if not 0.0 <= pixel_weight <= 1.0:
+            raise ValueError("pixel_weight must be within [0, 1]")
+        if not 0.0 <= shape_weight <= 1.0:
+            raise ValueError("shape_weight must be within [0, 1]")
+        if not 0.0 <= behaviour_weight <= 1.0:
+            raise ValueError("behaviour_weight must be within [0, 1]")
+        self.pixel_weight = pixel_weight
+        self.shape_weight = shape_weight
+        self.behaviour_weight = behaviour_weight
+        self.length_penalty = length_penalty
+
+    def grade(
+        self,
+        predictions: Sequence[Array],
+        targets: Sequence[Array],
+        program: Program,
+        behavioural_signal: float,
+    ) -> RewardBreakdown:
+        if len(predictions) != len(targets):
+            raise ValueError("predictions and targets length mismatch")
+
+        pixel_scores: List[float] = []
+        shape_scores: List[float] = []
+        for pred, tgt in zip(predictions, targets):
+            if pred.shape != tgt.shape:
+                shape_scores.append(0.0)
+            else:
+                shape_scores.append(1.0)
+            total = tgt.size
+            if total == 0:
+                pixel_scores.append(1.0)
+                continue
+            matches = float(np.sum(pred == tgt))
+            pixel_scores.append(matches / float(total))
+
+        pixel_accuracy = float(np.mean(pixel_scores)) if pixel_scores else 0.0
+        shape_accuracy = float(np.mean(shape_scores)) if shape_scores else 0.0
+        behaviour_bonus = max(0.0, min(1.0, behavioural_signal))
+        penalty = self.length_penalty * max(0, len(program) - 1)
+        reward = (
+            pixel_accuracy * self.pixel_weight
+            + shape_accuracy * self.shape_weight
+            + behaviour_bonus * self.behaviour_weight
+        )
+        reward = max(0.0, min(1.0, reward - penalty))
+        return RewardBreakdown(
+            pixel_accuracy=pixel_accuracy,
+            shape_accuracy=shape_accuracy,
+            behaviour_bonus=behaviour_bonus,
+            program_length_penalty=penalty,
+            reward=reward,
+        )
+
+
+@dataclass
+class BehaviouralMetrics:
+    """Aggregated telemetry for monitoring training runs."""
+
+    tasks_trained: int = 0
+    successful_tasks: int = 0
+    cumulative_reward: float = 0.0
+    pixel_moving_avg: MovingAverage = field(default_factory=lambda: MovingAverage(window=50))
+
+    def update(self, breakdown: RewardBreakdown, solved: bool) -> None:
+        self.tasks_trained += 1
+        if solved:
+            self.successful_tasks += 1
+        self.cumulative_reward += breakdown.reward
+        self.pixel_moving_avg.add_sample(breakdown.pixel_accuracy)
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "tasks_trained": float(self.tasks_trained),
+            "successful_tasks": float(self.successful_tasks),
+            "success_rate": (
+                float(self.successful_tasks) / float(self.tasks_trained)
+                if self.tasks_trained
+                else 0.0
+            ),
+            "cumulative_reward": self.cumulative_reward,
+            "pixel_accuracy_ma": self.pixel_moving_avg.value,
+        }
+
+
+class BehavioralEngine:
+    """Top-level operant conditioning loop for the solver."""
+
+    def __init__(
+        self,
+        dataset_loader: Optional[Callable[[Path], Dict[str, Dict[str, List]]]] = None,
+        solutions_loader: Optional[Callable[[Path], Dict[str, List[List[List[int]]]]]] = None,
+        search_factory: Callable[[], EnhancedSearch] = EnhancedSearch,
+        reward_grader: Optional[RewardGrader] = None,
+        feature_toggle: Optional[FeatureToggle] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._toggle = feature_toggle or FeatureToggle()
+        self._dataset_loader = dataset_loader or load_challenges
+        self._solutions_loader = solutions_loader or load_solutions
+        self._search_factory = search_factory
+        self._reward_grader = reward_grader or RewardGrader()
+        self._logger = logger or logging.getLogger(self.__class__.__name__)
+        if not self._logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s %(name)s %(levelname)s %(message)s"
+            )
+            handler.setFormatter(formatter)
+            self._logger.addHandler(handler)
+            self._logger.setLevel(logging.INFO)
+        self.metrics = BehaviouralMetrics()
+        self._rng = random.Random(0)
+
+    def train(
+        self,
+        dataset_path: Path,
+        solutions_path: Path,
+        max_tasks: Optional[int] = None,
+        seed: int = 0,
+        shuffle: bool = True,
+    ) -> BehaviouralMetrics:
+        """Execute the reinforcement training loop."""
+
+        if not self._toggle.enabled:
+            raise RuntimeError(
+                "Behavioural engine disabled – set PUMA_BEHAVIORAL_ENGINE=1 to train"
+            )
+
+        dataset_path = dataset_path.resolve(strict=True)
+        solutions_path = solutions_path.resolve(strict=True)
+
+        tasks = self._dataset_loader(dataset_path)
+        solutions = self._solutions_loader(solutions_path)
+        task_ids = list(tasks.keys())
+        self._rng.seed(seed)
+        if shuffle:
+            self._rng.shuffle(task_ids)
+        if max_tasks is not None:
+            task_ids = task_ids[:max_tasks]
+
+        search = self._search_factory()
+        guidance: NeuralGuidance = search.neural_guidance
+        episodic: EpisodicRetrieval = search.episodic_retrieval
+        rft_engine = RFTEngine()
+
+        for task_id in task_ids:
+            task = tasks[task_id]
+            try:
+                train_pairs = self._convert_pairs(task["train"])
+            except KeyError as exc:
+                raise ValueError(f"task {task_id} missing train pairs") from exc
+            if not train_pairs:
+                continue
+            gt_outputs = self._ground_truth_outputs(task_id, task, solutions)
+            inference = rft_engine.analyse(train_pairs)
+            best_program, best_breakdown = self._evaluate_programs(search, train_pairs, gt_outputs, inference)
+            if best_program is None or best_breakdown is None:
+                continue
+            solved = best_breakdown.reward > 0.999
+            guidance.reinforce(train_pairs, best_program, best_breakdown.reward, inference)
+            episodic.add_successful_solution(
+                train_pairs,
+                [best_program],
+                task_id=task_id,
+                reward=best_breakdown.reward,
+                metadata={
+                    "pixel_accuracy": best_breakdown.pixel_accuracy,
+                    "shape_accuracy": best_breakdown.shape_accuracy,
+                    "behaviour_bonus": best_breakdown.behaviour_bonus,
+                },
+            )
+            self.metrics.update(best_breakdown, solved)
+            self._emit_metrics(task_id, best_program, best_breakdown)
+
+        episodic.save()
+        return self.metrics
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _convert_pairs(self, raw_pairs: Iterable[Dict[str, List[List[int]]]]) -> List[TrainPair]:
+        pairs: List[TrainPair] = []
+        for pair in raw_pairs:
+            inp = np.array(pair["input"], dtype=int)
+            out = np.array(pair["output"], dtype=int)
+            pairs.append((inp, out))
+        return pairs
+
+    def _ground_truth_outputs(
+        self,
+        task_id: str,
+        task: Dict[str, List],
+        solutions: Dict[str, List[List[List[int]]]],
+    ) -> List[Array]:
+        outputs: List[Array] = []
+        if task_id in solutions:
+            for grid in solutions[task_id]:
+                outputs.append(np.array(grid, dtype=int))
+        else:
+            for pair in task.get("train", []):
+                outputs.append(np.array(pair["output"], dtype=int))
+        return outputs
+
+    def _evaluate_programs(
+        self,
+        search: EnhancedSearch,
+        train_pairs: List[TrainPair],
+        outputs: List[Array],
+        inference: RFTInference,
+        max_candidates: int = 16,
+    ) -> Tuple[Optional[Program], Optional[RewardBreakdown]]:
+        programs = search.synthesize_enhanced(train_pairs, max_programs=max_candidates)
+        best_program: Optional[Program] = None
+        best_breakdown: Optional[RewardBreakdown] = None
+        for program in programs:
+            predictions: List[Array] = []
+            try:
+                for inp, _ in train_pairs:
+                    predictions.append(apply_program(inp, program))
+            except Exception:
+                continue
+            behavioural_signal = inference.estimate_behavioural_signal(program)
+            breakdown = self._reward_grader.grade(predictions, outputs[: len(predictions)], program, behavioural_signal)
+            if best_breakdown is None or breakdown.reward > best_breakdown.reward:
+                best_breakdown = breakdown
+                best_program = program
+        return best_program, best_breakdown
+
+    def _emit_metrics(
+        self,
+        task_id: str,
+        program: Program,
+        breakdown: RewardBreakdown,
+    ) -> None:
+        payload = {
+            "task_id": task_id,
+            "reward": breakdown.reward,
+            "pixel_accuracy": breakdown.pixel_accuracy,
+            "shape_accuracy": breakdown.shape_accuracy,
+            "behaviour_bonus": breakdown.behaviour_bonus,
+            "program_length": len(program),
+            "global": self.metrics.as_dict(),
+        }
+        self._logger.info(json.dumps(payload, sort_keys=True))
+
+
+# [S:API v1] route=BehavioralEngine.train feature_flag=PUMA_BEHAVIORAL_ENGINE metrics=structured_json pass
+
+
+def load_challenges(path: Path) -> Dict[str, Dict[str, List]]:
+    """Load ARC challenge file into a dictionary keyed by task id."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("challenge file must contain a mapping of tasks")
+    return {str(task_id): task for task_id, task in data.items()}
+
+
+def load_solutions(path: Path) -> Dict[str, List[List[List[int]]]]:
+    """Load ARC solutions JSON and normalise keys to strings."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("solutions file must contain a mapping of tasks")
+    return {str(task_id): value for task_id, value in data.items()}

--- a/arc_solver/neural/episodic.py
+++ b/arc_solver/neural/episodic.py
@@ -50,6 +50,8 @@ class Episode:
     train_pairs: List[Tuple[Array, Array]] = field(default_factory=list)
     success_count: int = 1
     metadata: Dict[str, Any] = field(default_factory=dict)
+    reward_total: float = 0.0
+    reward_count: int = 0
     features: Dict[str, Any] = field(init=False)
 
     def __post_init__(self) -> None:
@@ -60,6 +62,17 @@ class Episode:
             )
         except Exception as exc:  # pragma: no cover - defensive programming
             raise ValueError(f"invalid training pairs for episode: {exc}") from exc
+
+    @property
+    def average_reward(self) -> float:
+        if self.reward_count <= 0:
+            return 0.0
+        return self.reward_total / float(self.reward_count)
+
+    def register_reward(self, reward: float) -> None:
+        reward = max(0.0, float(reward))
+        self.reward_total += reward
+        self.reward_count += 1
 
     # ------------------------------------------------------------------
     # Serialization helpers
@@ -78,6 +91,8 @@ class Episode:
             ],
             "success_count": self.success_count,
             "metadata": self.metadata,
+            "reward_total": self.reward_total,
+            "reward_count": self.reward_count,
             "features": self.features,
         }
 
@@ -111,6 +126,8 @@ class Episode:
             train_pairs=train_pairs,
             success_count=data.get("success_count", 1),
             metadata=data.get("metadata", {}),
+            reward_total=float(data.get("reward_total", 0.0)),
+            reward_count=int(data.get("reward_count", 0)),
         )
         # If features were stored, reuse them to avoid recomputation
         if "features" in data:
@@ -217,6 +234,7 @@ class EpisodeDatabase:
         task_id: str,
         train_pairs: List[Tuple[Array, Array]],
         metadata: Optional[Dict[str, Any]] = None,
+        reward: Optional[float] = None,
     ) -> int:
         """Store a solved episode and return its identifier."""
         episode = Episode(
@@ -226,6 +244,8 @@ class EpisodeDatabase:
             train_pairs=train_pairs,
             metadata=metadata or {},
         )
+        if reward is not None:
+            episode.register_reward(reward)
 
         episode_id = self._next_id
         self._next_id += 1
@@ -304,6 +324,8 @@ class EpisodeDatabase:
         results = self.query_hierarchy(train_pairs, 0.0, max_programs)
         if not results:
             results = self.query_by_similarity(train_pairs, 0.0, max_programs)
+        # Sort by reward-aware priority
+        results.sort(key=lambda item: (item[0].average_reward, item[1]), reverse=True)
         for episode, _ in results:
             for program in episode.programs:
                 candidates.append(program)
@@ -441,11 +463,20 @@ class EpisodicRetrieval:
         train_pairs: List[Tuple[Array, Array]],
         programs: List[Program],
         task_id: str = "",
+        reward: Optional[float] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Store a successful solution in the episodic database."""
 
         signature = compute_task_signature(train_pairs)
-        self.database.store_episode(signature, programs, task_id, train_pairs)
+        self.database.store_episode(
+            signature,
+            programs,
+            task_id,
+            train_pairs,
+            metadata=metadata,
+            reward=reward,
+        )
         self.cache.clear()
 
     def save(self) -> None:

--- a/arc_solver/rft_engine/__init__.py
+++ b/arc_solver/rft_engine/__init__.py
@@ -1,0 +1,3 @@
+"""Relational Frame Theory engine for the ARC solver."""
+
+# [S:PKG v1] module=arc_solver.rft status=initialised pass

--- a/arc_solver/rft_engine/engine.py
+++ b/arc_solver/rft_engine/engine.py
@@ -1,0 +1,225 @@
+"""Lightweight Relational Frame Theory inference engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from ..object_reasoning import ObjectExtractor, SpatialAnalyzer
+from ..grid import Array
+
+
+@dataclass
+class RelationalFact:
+    """Single relation between two abstract stimuli."""
+
+    source: str
+    target: str
+    frame: str
+    context: str
+    confidence: float
+
+
+@dataclass
+class RFTInference:
+    """Inference bundle returned by :class:`RFTEngine`."""
+
+    relations: List[RelationalFact]
+    function_hints: Dict[str, Set[str]]
+
+    def estimate_behavioural_signal(self, program: Sequence[Tuple[str, Dict[str, int]]]) -> float:
+        """Return bonus proportional to overlap between hints and program ops."""
+
+        if not program or not self.function_hints:
+            return 0.0
+        program_ops = {op for op, _ in program}
+        hinted_ops: Set[str] = set()
+        for hints in self.function_hints.values():
+            hinted_ops.update(hints)
+        if not hinted_ops:
+            return 0.0
+        matched = len(program_ops & hinted_ops)
+        return min(1.0, matched / max(1, len(hinted_ops)))
+
+
+class RFTEngine:
+    """Extracts relational frames and functional hints from training pairs."""
+
+    def __init__(self) -> None:
+        self._extractor = ObjectExtractor()
+        self._spatial = SpatialAnalyzer()
+
+    def analyse(self, train_pairs: Iterable[Tuple[Array, Array]]) -> RFTInference:
+        relations: List[RelationalFact] = []
+        function_hints: Dict[str, Set[str]] = {}
+
+        for idx, (inp, out) in enumerate(train_pairs):
+            objects_in = self._extractor.extract_objects(inp)
+            objects_out = self._extractor.extract_objects(out)
+            mapping = self._match_objects(objects_in, objects_out)
+
+            for obj_in in objects_in:
+                node_id = self._node_id(idx, "input", obj_in.id)
+                function_hints.setdefault(node_id, set())
+                if obj_in.id in mapping:
+                    out_obj = mapping[obj_in.id]
+                    target_id = self._node_id(idx, "output", out_obj.id)
+                    relations.extend(self._derive_relations(node_id, target_id, obj_in, out_obj))
+                    hints = self._derive_function_hints(obj_in, out_obj)
+                    if hints:
+                        function_hints[node_id].update(hints)
+                        function_hints.setdefault(target_id, set()).update(hints)
+                else:
+                    function_hints[node_id].add("delete")
+
+            for obj_out in objects_out:
+                node_id = self._node_id(idx, "output", obj_out.id)
+                function_hints.setdefault(node_id, set())
+                if obj_out.id not in mapping.values():
+                    function_hints[node_id].add("create")
+
+            relations.extend(self._spatial_relations(idx, objects_in, objects_out))
+
+        self._apply_entailment(relations)
+        self._transform_functions(relations, function_hints)
+
+        return RFTInference(relations=relations, function_hints=function_hints)
+
+    # ------------------------------------------------------------------
+    # Relational extraction helpers
+    # ------------------------------------------------------------------
+    def _match_objects(
+        self,
+        inputs: Sequence,
+        outputs: Sequence,
+    ) -> Dict[int, object]:
+        matches: Dict[int, object] = {}
+        used: Set[int] = set()
+        for obj in inputs:
+            best_idx: Optional[int] = None
+            best_score = -1.0
+            for cand in outputs:
+                if cand.id in used:
+                    continue
+                score = self._shape_similarity(obj, cand)
+                if score > best_score:
+                    best_score = score
+                    best_idx = cand.id
+            if best_idx is not None and best_score > 0.3:
+                used.add(best_idx)
+                matches[obj.id] = next(c for c in outputs if c.id == best_idx)
+        return matches
+
+    def _shape_similarity(self, obj_a, obj_b) -> float:
+        size_ratio = min(obj_a.size, obj_b.size) / max(obj_a.size, obj_b.size)
+        if size_ratio == 0:
+            return 0.0
+        width_ratio = min(obj_a.width, obj_b.width) / max(obj_a.width, obj_b.width)
+        height_ratio = min(obj_a.height, obj_b.height) / max(obj_a.height, obj_b.height)
+        shape_bonus = 1.0 if obj_a.shape_type == obj_b.shape_type else 0.0
+        return 0.5 * size_ratio + 0.2 * width_ratio + 0.2 * height_ratio + 0.1 * shape_bonus
+
+    def _derive_relations(self, source_id: str, target_id: str, obj_in, obj_out) -> List[RelationalFact]:
+        relations: List[RelationalFact] = []
+        if obj_in.color == obj_out.color:
+            relations.append(RelationalFact(source_id, target_id, "coordination", "color", 0.9))
+        else:
+            relations.append(RelationalFact(source_id, target_id, "opposition", "color", 0.8))
+        translation = self._translation_vector(obj_in, obj_out)
+        if translation is not None:
+            relations.append(
+                RelationalFact(
+                    source_id,
+                    target_id,
+                    "comparison",
+                    f"translation:{translation[0]}:{translation[1]}",
+                    0.85,
+                )
+            )
+        return relations
+
+    def _derive_function_hints(self, obj_in, obj_out) -> Set[str]:
+        hints: Set[str] = set()
+        if obj_in.color != obj_out.color:
+            hints.add("recolor")
+        translation = self._translation_vector(obj_in, obj_out)
+        if translation and translation != (0, 0):
+            hints.add("translate")
+        if obj_in.size != obj_out.size:
+            hints.add("resize")
+        return hints
+
+    def _translation_vector(self, obj_in, obj_out) -> Optional[Tuple[int, int]]:
+        if obj_in.size != obj_out.size:
+            return None
+        min_r_in, min_c_in, _, _ = obj_in.bounding_box
+        min_r_out, min_c_out, _, _ = obj_out.bounding_box
+        return (min_r_out - min_r_in, min_c_out - min_c_in)
+
+    def _spatial_relations(self, idx: int, inputs, outputs) -> List[RelationalFact]:
+        relations: List[RelationalFact] = []
+        combined = list(inputs) + list(outputs)
+        if not combined:
+            return relations
+        for rel in self._spatial.analyze_relations(combined):
+            node_a = self._node_id(idx, "spatial", rel.obj1_id)
+            node_b = self._node_id(idx, "spatial", rel.obj2_id)
+            relations.append(
+                RelationalFact(
+                    node_a,
+                    node_b,
+                    "spatial",
+                    rel.relation,
+                    rel.confidence,
+                )
+            )
+        return relations
+
+    def _apply_entailment(self, relations: List[RelationalFact]) -> None:
+        symmetrical = []
+        transitive_candidates: Dict[str, List[RelationalFact]] = {}
+        for rel in relations:
+            if rel.frame in {"coordination", "opposition", "comparison"}:
+                symmetrical.append(
+                    RelationalFact(rel.target, rel.source, rel.frame, rel.context, rel.confidence)
+                )
+            if rel.frame == "comparison" and rel.context.startswith("translation"):
+                key = rel.context
+                transitive_candidates.setdefault(key, []).append(rel)
+        relations.extend(symmetrical)
+        for rel_list in transitive_candidates.values():
+            for i in range(len(rel_list)):
+                for j in range(len(rel_list)):
+                    if rel_list[i].target == rel_list[j].source:
+                        relations.append(
+                            RelationalFact(
+                                rel_list[i].source,
+                                rel_list[j].target,
+                                "comparison",
+                                rel_list[i].context,
+                                min(rel_list[i].confidence, rel_list[j].confidence),
+                            )
+                        )
+
+    def _transform_functions(self, relations: List[RelationalFact], hints: Dict[str, Set[str]]) -> None:
+        adjacency: Dict[str, Set[str]] = {}
+        for rel in relations:
+            adjacency.setdefault(rel.source, set()).add(rel.target)
+        updated = True
+        while updated:
+            updated = False
+            for source, neighbours in adjacency.items():
+                source_hints = hints.get(source, set())
+                for neighbour in neighbours:
+                    if neighbour not in hints:
+                        hints[neighbour] = set()
+                    before = len(hints[neighbour])
+                    hints[neighbour].update(source_hints)
+                    if len(hints[neighbour]) > before:
+                        updated = True
+
+    def _node_id(self, pair_idx: int, domain: str, obj_id: int) -> str:
+        return f"{pair_idx}:{domain}:{obj_id}"
+
+
+# [S:ALG v1] component=rft_engine entailment=mutual+transitive pass

--- a/arc_solver/utils/__init__.py
+++ b/arc_solver/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for the ARC solver package."""
+
+# [S:PKG v1] module=arc_solver.utils status=initialised pass

--- a/arc_solver/utils/metrics.py
+++ b/arc_solver/utils/metrics.py
@@ -1,0 +1,35 @@
+"""Metrics utilities with deterministic moving averages."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque
+
+
+class MovingAverage:
+    """Fixed-window moving average with deterministic updates."""
+
+    def __init__(self, window: int) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self.window = window
+        self._buffer: Deque[float] = deque(maxlen=window)
+        self._running_sum: float = 0.0
+
+    def add_sample(self, value: float) -> None:
+        if not isinstance(value, (int, float)):
+            raise TypeError("value must be numeric")
+        if len(self._buffer) == self.window:
+            oldest = self._buffer[0]
+            self._running_sum -= oldest
+        self._buffer.append(float(value))
+        self._running_sum += float(value)
+
+    @property
+    def value(self) -> float:
+        if not self._buffer:
+            return 0.0
+        return self._running_sum / float(len(self._buffer))
+
+
+# [S:UTIL v1] component=moving_average windowed pass

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,3 +96,14 @@ The system incorporates core knowledge priors that mirror human reasoning:
 5. **Curriculum Learning**: Progressive difficulty training
 
 This architecture provides a strong foundation for achieving the 85% accuracy target on ARC-AGI-2 while staying within Kaggle's compute constraints.
+
+## Functional Contextualist Extension
+
+The complementary behavioral roadmap described in
+[`functional_contextualist_architecture.md`](functional_contextualist_architecture.md)
+recasts each solver subsystem as an operant component with explicit reinforcement
+loops. The production `BehavioralEngine` (`arc_solver/behavioral_engine.py`) now
+implements the reinforcement loop, while the new `RFTEngine`
+(`arc_solver/rft_engine/engine.py`) supplies derived relational hints to neural
+guidance. Refer to that document for remaining tacting extensions and future RFT
+expansions.

--- a/docs/functional_contextualist_architecture.md
+++ b/docs/functional_contextualist_architecture.md
@@ -1,0 +1,98 @@
+[S:DOC v2] doc=functional_contextualist_architecture sections=5 scope=behavioral pass
+
+# A Functional Contextualist Architecture for Abstract Reasoning: Integrating Behavioral Analysis into the PUMA Solver
+
+## 1. Architectural Analysis of PUMA as a Behavioral System
+
+### 1.1 Neuroscience-Inspired Foundations
+- **Multiple-Demand (MD) Network Analog** — `arc_solver/neural/guidance.py`
+- **Basal Ganglia Gating Analog** — `arc_solver/enhanced_search.py`
+- **Hippocampal–mPFC Loop Analog** — `arc_solver/neural/episodic.py`
+- **Test-Time Adaptation Analog** — `arc_solver/ttt.py`
+
+### 1.2 Behavioral Deconstruction (A–B–C Model)
+| Element | PUMA Realisation | Notes |
+| --- | --- | --- |
+| Antecedent Stimulus | ARC task grids (`data/arc-agi_training_challenges.json`) | Input demonstrations/tables |
+| Behavior (Operant) | Synthesised DSL program (`arc_solver/dsl.py`, `arc_solver/dsl_complete.py`) | Candidate solutions |
+| Consequence | Correctness evaluation (`evaluate_performance.py`) | Reward signal |
+
+**Stimulus Control:** NeuralGuidance adapts operation probabilities from features (`arc_solver/features.py`).
+
+**Learning History:** EpisodicRetrieval stores reinforced program traces (`episodes.json`).
+
+### 1.3 Review of Relational Modules
+- `arc_solver/object_reasoning.py` provides object descriptors.
+- `arc_solver/human_reasoning.py` encodes static geometric relations.
+- Current system lacks operant relational learning — relations are hand-engineered rather than learned frames.
+
+## 2. Re-Imagining the DSL as Verbal Behavior
+
+### 2.1 Skinnerian Foundations
+- **Tacts:** Labeling environmental stimuli.
+- **Intraverbals:** Chains of verbal responses controlled by preceding responses.
+- **Mands:** Responses motivated by establishing operations.
+
+### 2.2 Tacting Module Proposal
+- Extend features/objects to produce learned symbolic descriptors.
+- Reinforce tact emission when associated programs solve tasks.
+
+### 2.3 Intraverbal Chaining for Program Synthesis
+- Treat program generation as conditional probability chain `P(op_n | grid_{n-1}, tacts)`.
+- Allow shaping via progressive reinforcement on partial programs.
+
+### 2.4 Behavioral Mapping Table
+| Behavioral Concept | Module | Function |
+| --- | --- | --- |
+| Antecedent Stimulus | ARC task input | Evokes behavior |
+| Behavior / Operant | DSL program | Acts on environment |
+| Consequence | Grader output | Reinforcement |
+| Reinforcement Mechanism | BehavioralEngine (`arc_solver/behavioral_engine.py`) | Reward delivery |
+| Stimulus Control | NeuralGuidance | Probability shaping |
+| Learning History | EpisodicRetrieval | Memory of reinforced behaviors |
+| Tacting | Proposed module atop `arc_solver/features.py` | Descriptive labeling |
+| Intraverbal Behavior | Enhanced search with chaining | Sequenced operations |
+| Relational Framing | RFTEngine (`arc_solver/rft_engine/engine.py`) | Derived relations |
+
+## 3. Engineering an RFT Engine for Novel Problem-Solving
+
+### 3.1 Multiple Exemplar Training
+- Mine relational patterns across solved tasks using object-centric state.
+
+### 3.2 Derived Relational Responding
+- Maintain relational graph with mutual/combinatorial entailment rules.
+
+### 3.3 Transformation of Stimulus Functions
+- Treat DSL applicability as stimulus functions.
+- Transfer functions across derived equivalent stimuli to generalise behavior.
+
+## 4. Implementation Roadmap
+
+### 4.1 BehavioralEngine
+- **Module:** `arc_solver/behavioral_engine.py`
+- **Feature flag:** `PUMA_BEHAVIORAL_ENGINE` guarantees opt-in rollouts.
+- **Reward Loop:** `RewardGrader` emits dense `[0.0, 1.0]` rewards with pixel/shape breakdowns.
+- **Telemetry:** Structured JSON logs + moving-average metrics for monitoring.
+- **Integration:** Broadcasts reinforcement to `NeuralGuidance.reinforce()` and episodic memory.
+
+### 4.2 Module Adaptations
+- **NeuralGuidance (`arc_solver/neural/guidance.py`):** Online updates from rewards and RFT hints.
+- **EpisodicRetrieval (`arc_solver/neural/episodic.py`):** Tracks average reward per episode and ranks retrieval accordingly.
+- **EnhancedSearch (`arc_solver/enhanced_search.py`):** Consumes updated guidance statistics without code changes.
+
+### 4.3 Agentic Integration
+- Embed RFT state into agentic solver observation space (`docs/AGENTIC_GENOMIC_SOLVER.md`).
+- Use RL loop with structured rewards for intermediate progress.
+
+## 5. Anticipated Capabilities and Future Work
+
+### 5.1 Novel Problem-Solving
+- Generalise via relational frames.
+- Encourage creative intraverbal chaining.
+
+### 5.2 Functional Contextualism in AI
+- Emphasises behavior shaped by consequences over static knowledge.
+
+### 5.3 Future Research
+- Explore deictic framing (I/You, Here/There, Now/Then).
+- Investigate self-modeling using extended RFT principles.

--- a/tests/test_behavioral_engine.py
+++ b/tests/test_behavioral_engine.py
@@ -1,0 +1,162 @@
+"""Tests for behavioural reinforcement components."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from arc_solver.behavioral_engine import (
+    BehavioralEngine,
+    FeatureToggle,
+    RewardGrader,
+    load_challenges,
+    load_solutions,
+)
+from arc_solver.behavioral_engine import RewardBreakdown
+from arc_solver.neural.guidance import NeuralGuidance
+from arc_solver.rft_engine.engine import RFTEngine, RFTInference
+
+
+@st.composite
+def grid_arrays(draw) -> np.ndarray:
+    height = draw(st.integers(min_value=1, max_value=3))
+    width = draw(st.integers(min_value=1, max_value=3))
+    values = draw(
+        st.lists(
+            st.lists(st.integers(min_value=0, max_value=9), min_size=width, max_size=width),
+            min_size=height,
+            max_size=height,
+        )
+    )
+    return np.array(values, dtype=int)
+
+
+@st.composite
+def prediction_target_pairs(draw) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    targets = draw(st.lists(grid_arrays(), min_size=1, max_size=3))
+    predictions: List[np.ndarray] = []
+    for target in targets:
+        candidate = target.copy()
+        if target.size and draw(st.booleans()):
+            idx = draw(st.integers(min_value=0, max_value=target.size - 1))
+            candidate = target.copy()
+            candidate.flat[idx] = (candidate.flat[idx] + 1) % 10
+        predictions.append(candidate)
+    return predictions, targets
+
+
+@given(data=prediction_target_pairs(), behavioural=st.floats(min_value=0, max_value=1))
+@settings(max_examples=25, deadline=None)
+def test_reward_grader_bounds(data: Tuple[List[np.ndarray], List[np.ndarray]], behavioural: float) -> None:
+    predictions, targets = data
+    grader = RewardGrader()
+    breakdown = grader.grade(predictions, targets, program=[("identity", {})], behavioural_signal=behavioural)
+    assert isinstance(breakdown, RewardBreakdown)
+    assert 0.0 <= breakdown.reward <= 1.0
+    assert 0.0 <= breakdown.pixel_accuracy <= 1.0
+    assert 0.0 <= breakdown.shape_accuracy <= 1.0
+
+
+def test_neural_guidance_reinforce_updates_stats() -> None:
+    guidance = NeuralGuidance()
+    train_pairs = [
+        (
+            np.array([[1, 0], [0, 0]], dtype=int),
+            np.array([[0, 1], [0, 0]], dtype=int),
+        )
+    ]
+    inference = RFTInference(relations=[], function_hints={"0:input:0": {"translate"}})
+    guidance.reinforce(train_pairs, [("translate", {"dx": 1, "dy": 0})], reward=0.75, inference=inference)
+    stats = guidance.operation_stats["translate"]
+    assert stats["count"] >= 1.0
+    assert 0.0 < stats["mean_reward"] <= 1.0
+    scores = guidance.score_operations(train_pairs)
+    assert scores["translate"] >= scores["identity"]
+
+
+def test_rft_engine_detects_translation() -> None:
+    arr_in = np.array([[0, 1, 0], [0, 0, 0], [0, 0, 0]], dtype=int)
+    arr_out = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=int)
+    inference = RFTEngine().analyse([(arr_in, arr_out)])
+    all_hints = {hint for hints in inference.function_hints.values() for hint in hints}
+    assert "translate" in all_hints
+
+
+class _StubEpisodic:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, float]] = []
+        self.saved = False
+
+    def add_successful_solution(self, train_pairs, programs, task_id="", reward=None, metadata=None):
+        self.calls.append({"reward": reward or 0.0, "task_id": task_id})
+
+    def save(self) -> None:
+        self.saved = True
+
+
+class _StubSearch:
+    def __init__(self) -> None:
+        self.neural_guidance = NeuralGuidance()
+        self.episodic_retrieval = _StubEpisodic()
+
+    def synthesize_enhanced(self, train_pairs, max_programs=256, expected_shape=None, test_input=None):
+        del train_pairs, max_programs, expected_shape, test_input
+        return [[("translate", {"dx": 0, "dy": 1})]]
+
+
+def test_behavioral_engine_training_cycle(tmp_path: Path) -> None:
+    dataset = {
+        "task_1": {
+            "train": [
+                {
+                    "input": [[0, 1], [0, 0]],
+                    "output": [[0, 0], [0, 1]],
+                }
+            ],
+            "test": [],
+        }
+    }
+    solutions = {"task_1": [[[0, 0], [0, 1]]]}
+    dataset_path = tmp_path / "challenges.json"
+    solutions_path = tmp_path / "solutions.json"
+    dataset_path.write_text(json.dumps(dataset))
+    solutions_path.write_text(json.dumps(solutions))
+
+    env_var = "PUMA_BEHAVIORAL_ENGINE"
+    old_value = os.environ.get(env_var)
+    os.environ[env_var] = "1"
+    try:
+        stub_holder: Dict[str, _StubSearch] = {}
+
+        def factory() -> _StubSearch:
+            stub = _StubSearch()
+            stub_holder["instance"] = stub
+            return stub
+
+        engine = BehavioralEngine(
+            dataset_loader=load_challenges,
+            solutions_loader=load_solutions,
+            search_factory=factory,
+            reward_grader=RewardGrader(pixel_weight=0.8, shape_weight=0.2, behaviour_weight=0.0, length_penalty=0.0),
+            feature_toggle=FeatureToggle(env_var=env_var),
+        )
+        metrics = engine.train(dataset_path, solutions_path, max_tasks=1, shuffle=False)
+    finally:
+        if old_value is None:
+            del os.environ[env_var]
+        else:
+            os.environ[env_var] = old_value
+
+    stub = stub_holder["instance"]
+    assert stub.episodic_retrieval.calls, "episodic memory should receive reward updates"
+    translate_stats = stub.neural_guidance.operation_stats["translate"]
+    assert translate_stats["count"] >= 1.0
+    assert metrics.tasks_trained == 1
+    assert metrics.cumulative_reward > 0.0
+    assert stub.episodic_retrieval.saved is True


### PR DESCRIPTION
## Summary
- add a feature-flagged `BehavioralEngine` with reward grading, structured telemetry, and dataset loaders for operant training
- implement an RFT inference engine plus moving-average utilities to supply relational hints and expose them through neural guidance and episodic memory
- update documentation and README with behavioral training instructions and add property/integration tests covering the new reinforcement loop

## Testing
- PYTHONPATH=. pytest tests/test_behavioral_engine.py -q
- PYTHONPATH=. pytest tests/test_agentic_small.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cdea7b6bd08322acd52923a0bc6c3d