### PR TITLE
[S:ALG v2] harden RFT pliance tracking integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+- [ ] What changed?
+- [ ] Why?
+
+## Testing
+- [ ] Steps
+- [ ] Results
+
+## Risk Assessment
+- [ ] Regressions considered
+- [ ] Rollback plan
+
+[S:PR v1] template=installed pass

--- a/puma/__init__.py
+++ b/puma/__init__.py
@@ -1,0 +1,10 @@
+"""PUMA meta-learning components."""
+from importlib import import_module
+
+__all__ = ["rft"]
+
+
+def __getattr__(name):
+    if name == "rft":
+        return import_module("puma.rft")
+    raise AttributeError(name)

--- a/puma/rft/README.md
+++ b/puma/rft/README.md
@@ -1,0 +1,104 @@
+# PUMA RFT Module
+
+[S:DOC v2] scope=puma.rft overview=complete pass
+
+The Relational Frame Theory (RFT) module adds pliance-based rule following and
+tracking-driven rule variation to the PUMA solver while remaining fully
+feature-flagged behind `PUMA_RFT`.
+
+## Architecture
+
+```
++-------------------+      +----------------------+      +------------------+
+| feature_flags     | ---> | pliance (determinism)| ---> | explain          |
++-------------------+      +----------------------+      +------------------+
+           |                         |                               ^
+           v                         v                               |
++-------------------+      +----------------------+      +------------------+
+| demo/grid harness | ---> | tracking (variation) | ---> | orchestrator     |
++-------------------+      +----------------------+      +------------------+
+```
+
+* `types.py` exposes typed primitives (rules, context, hypotheses).
+* `pliance.py` executes prioritized rules deterministically.
+* `tracking.py` evaluates adaptive hypotheses and promotes successful ones.
+* `orchestrator.py` alternates pliance and tracking with metrics and guards.
+* `explain.py` records rich traces surfaced via `explain_last_run()`.
+
+## Usage
+
+1. Enable the feature flag: `export PUMA_RFT=1`.
+2. Run the demo tests: `pytest tests/rft/test_rft_integration.py -q`.
+3. Inspect the most recent trace:
+
+   ```python
+   from puma.rft.explain import explain_last_run
+   print(explain_last_run())
+   ```
+
+To exercise the adapter inside the ARC solver:
+
+```bash
+PUMA_RFT=1 python -c 'from arc_solver import ARCSolver; solver = ARCSolver();
+print(solver.solve_task({"train": [...], "test": [...], "metadata":
+{"rft_demo": {"grid": {"grid": [[0,1,0]], "targets": [[0,0],[0,1],[0,2]],
+"inject_output": true}}}}))'
+```
+
+### Demo promotion proof
+
+Copy-paste the snippet below to verify a promotion and trace:
+
+```bash
+PUMA_RFT=1 python - <<'PY'
+from puma.rft.demo.grid import build_context
+from puma.rft.orchestrator import solve_with_rft
+from puma.rft.tracking import HypothesisMemory
+from puma.rft.feature_flags import build_limits
+from puma.rft.explain import explain_last_run
+
+grid = [
+    [0, 1],
+    [2, 1],
+    [2, 1],
+]
+targets = [(r, 0) for r in range(len(grid))]
+context, rules = build_context(grid, targets, build_limits())
+memory = HypothesisMemory()
+context, status = solve_with_rft(context, rules, memory, outer_budget=4)
+print(status)
+print(explain_last_run(context))
+PY
+```
+
+Expected output (abridged):
+
+```
+DONE
+Status: GOAL
+Top hypotheses:
+  - propagate 0 by (1,0) regardless of color (score=1.00)
+Promoted rules:
+  - track_1_0_broad (score=1.00)
+Metrics: ... tracking_promotions=1 ...
+```
+
+## Observability
+
+Structured debug logs are emitted under the `puma.rft.*` namespace. Metrics are
+collected on the context (e.g., `pliance_rule_fires`, `tracking_hypotheses_evaluated`)
+and surfaced via `explain_last_run`.
+
+## Tracking score
+
+Hypothesis tracking uses the explicit scoring rule described in the spec:
+
+```
+progress = satisfied_targets / total_targets
+simplicity = len(active_conditions)
+score = progress - 0.1 * simplicity
+```
+
+Scores greater than the configured threshold (`RFT_DEFAULT_LIMITS["THRESH"]`) are
+promoted. Simplicity penalties ensure compact rules are favoured when progress is
+equivalent.

--- a/puma/rft/__init__.py
+++ b/puma/rft/__init__.py
@@ -1,0 +1,37 @@
+"""Relational Frame Theory inspired solving primitives for PUMA."""
+# [S:DESIGN v1] package=rft_core pass
+
+from .feature_flags import RFT_ENABLED, RFT_DEFAULT_LIMITS, build_limits
+from .types import Entity, Relation, Rule, Context, Hypothesis, Limits
+from .pliance import pliance_solve
+from .tracking import (
+    generate_variations,
+    evaluate_hypothesis,
+    promote_to_rule,
+    HypothesisMemory,
+    tracking_step,
+)
+from .orchestrator import solve_with_rft, insert_after_stuck_rule
+from .explain import explain_last_run, record_trace
+
+__all__ = [
+    "RFT_ENABLED",
+    "RFT_DEFAULT_LIMITS",
+    "build_limits",
+    "Entity",
+    "Relation",
+    "Rule",
+    "Context",
+    "Hypothesis",
+    "Limits",
+    "pliance_solve",
+    "generate_variations",
+    "evaluate_hypothesis",
+    "promote_to_rule",
+    "HypothesisMemory",
+    "tracking_step",
+    "solve_with_rft",
+    "insert_after_stuck_rule",
+    "explain_last_run",
+    "record_trace",
+]

--- a/puma/rft/demo/grid.py
+++ b/puma/rft/demo/grid.py
@@ -1,0 +1,326 @@
+"""Minimal grid harness for exercising RFT pliance and tracking."""
+# [S:HARNESS v1] fixture=grid_demo pass
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+from ..feature_flags import build_limits
+from ..types import Context, Hypothesis, Limits, Rule
+
+logger = logging.getLogger("puma.rft.demo.grid")
+logger.addHandler(logging.NullHandler())
+
+Coord = Tuple[int, int]
+Grid = List[List[str]]
+
+
+def _clone_grid(grid: Grid) -> Grid:
+    return [row[:] for row in grid]
+
+
+@dataclass
+class GridState:
+    """2D grid with target cells that must become black."""
+
+    grid: Grid
+    targets: Set[Coord]
+    seed_color: object = 0
+    metadata: Dict[str, object] = field(default_factory=dict)
+    fixpoint_triggered: bool = False
+
+    def clone(self) -> "GridState":
+        return GridState(
+            grid=_clone_grid(self.grid),
+            targets=set(self.targets),
+            seed_color=self.seed_color,
+            metadata=dict(self.metadata),
+            fixpoint_triggered=self.fixpoint_triggered,
+        )
+
+    @property
+    def height(self) -> int:
+        return len(self.grid)
+
+    @property
+    def width(self) -> int:
+        return len(self.grid[0]) if self.grid else 0
+
+    def begin_iteration(self, step: int) -> None:
+        self.metadata["iteration"] = step
+        self.metadata["changed"] = False
+
+    def end_iteration(self, step: int, fired: bool) -> None:
+        self.metadata["changed_last"] = self.metadata.get("changed", False)
+
+    def mark_changed(self) -> None:
+        self.metadata["changed"] = True
+
+    def in_bounds(self, coord: Coord) -> bool:
+        r, c = coord
+        return 0 <= r < self.height and 0 <= c < self.width
+
+    def get(self, coord: Coord) -> str:
+        r, c = coord
+        return self.grid[r][c]
+
+    def set(self, coord: Coord, value: str) -> None:
+        r, c = coord
+        self.grid[r][c] = value
+        self.mark_changed()
+
+    def progress(self) -> float:
+        if not self.targets:
+            return 1.0
+        satisfied = sum(1 for coord in self.targets if self.get(coord) == self.seed_color)
+        return satisfied / len(self.targets)
+
+    def unsatisfied_targets(self) -> List[Coord]:
+        return [coord for coord in sorted(self.targets) if self.get(coord) != self.seed_color]
+
+    def satisfied_sources(self) -> List[Coord]:
+        coords: List[Coord] = []
+        for r in range(self.height):
+            for c in range(self.width):
+                if self.grid[r][c] == self.seed_color:
+                    coords.append((r, c))
+        return coords
+
+    def neighbor_offsets(self) -> List[Coord]:
+        return [
+            (-1, 0),
+            (1, 0),
+            (0, -1),
+            (0, 1),
+            (-1, -1),
+            (-1, 1),
+            (1, -1),
+            (1, 1),
+        ]
+
+    def candidate_hypotheses(
+        self,
+        context: Context,
+        base_rules: Sequence[Rule],
+        memory: object,
+    ) -> List[Hypothesis]:
+        candidates: List[Hypothesis] = []
+        seen: Set[Tuple[Coord, int, Tuple[Tuple[str, str], ...]]] = set()
+        for target in self.unsatisfied_targets():
+            for dr, dc in self.neighbor_offsets():
+                source = (target[0] - dr, target[1] - dc)
+                if not self.in_bounds(source):
+                    continue
+                if self.get(source) != self.seed_color:
+                    continue
+                conditions: List[Dict[str, str]] = []
+                target_color = self.get(target)
+                if target_color != self.seed_color:
+                    conditions.append({"target_color": target_color})
+                cond_key = tuple(sorted(tuple(sorted(cond.items())) for cond in conditions))
+                key = ((dr, dc), 1, cond_key)
+                if key in seen:
+                    continue
+                seen.add(key)
+                desc = f"propagate {self.seed_color} by ({dr},{dc})"
+                params = {
+                    "direction": (dr, dc),
+                    "radius": 1,
+                    "conditions": conditions,
+                    "priority": 30,
+                    "name": f"track_{dr}_{dc}_{len(conditions)}",
+                    "promote_hook": promote_grid_rule,
+                }
+                candidates.append(Hypothesis(desc, variation_of="R1", params=params))
+                if not conditions:
+                    continue
+                # Condition-free alternative to test scope variation.
+                alt_key = ((dr, dc), 1, tuple())
+                if alt_key not in seen:
+                    alt_params = dict(params)
+                    alt_params["conditions"] = []
+                    alt_params["name"] = f"track_{dr}_{dc}_broad"
+                    seen.add(alt_key)
+                    candidates.append(
+                        Hypothesis(
+                            f"propagate {self.seed_color} by ({dr},{dc}) regardless of color",
+                            variation_of="R1",
+                            params=alt_params,
+                        )
+                    )
+        # Radius-based variations for diagonals or gaps.
+        for target in self.unsatisfied_targets():
+            for dr, dc in self.neighbor_offsets():
+                source = (target[0] - 2 * dr, target[1] - 2 * dc)
+                if not self.in_bounds(source):
+                    continue
+                if self.get(source) != self.seed_color:
+                    continue
+                params = {
+                    "direction": (dr, dc),
+                    "radius": 2,
+                    "conditions": [],
+                    "priority": 40,
+                    "name": f"track_radius2_{dr}_{dc}",
+                    "promote_hook": promote_grid_rule,
+                }
+                key = ((dr, dc), 2, tuple())
+                if key in seen:
+                    continue
+                seen.add(key)
+                candidates.append(
+                    Hypothesis(
+                        f"propagate {self.seed_color} by ({dr},{dc}) with radius 2",
+                        variation_of="R1",
+                        params=params,
+                    )
+                )
+        return candidates
+
+    def _conditions_met(self, source: Coord, target: Coord, conditions: Sequence[Dict[str, str]]) -> bool:
+        for cond in conditions:
+            src_color = cond.get("source_color")
+            if src_color is not None and self.get(source) != src_color:
+                return False
+            tgt_color = cond.get("target_color")
+            if tgt_color is not None and self.get(target) != tgt_color:
+                return False
+        return True
+
+    def propagate(
+        self,
+        direction: Coord,
+        radius: int = 1,
+        conditions: Sequence[Dict[str, str]] | None = None,
+        mutate: bool = True,
+    ) -> int:
+        conditions = conditions or []
+        changed = 0
+        while True:
+            to_paint: List[Coord] = []
+            for r, c in self.satisfied_sources():
+                target = (r + direction[0] * radius, c + direction[1] * radius)
+                if not self.in_bounds(target):
+                    continue
+                if self.get(target) == self.seed_color:
+                    continue
+                if not self._conditions_met((r, c), target, conditions):
+                    continue
+                to_paint.append(target)
+            if not to_paint:
+                break
+            changed += len(to_paint)
+            for coord in to_paint:
+                self.set(coord, self.seed_color)
+            if not mutate:
+                break
+        return changed
+
+    def evaluate_hypothesis(self, hypothesis: Hypothesis, context: Context) -> Dict[str, object]:
+        clone = self.clone()
+        direction = tuple(hypothesis.params.get("direction", (0, 1)))
+        radius = int(hypothesis.params.get("radius", 1))
+        conditions = hypothesis.params.get("conditions", [])
+        changed = clone.propagate(direction, radius=radius, conditions=conditions, mutate=True)
+        return {
+            "progress": clone.progress(),
+            "changed": changed,
+            "direction": direction,
+            "radius": radius,
+            "conditions": conditions,
+        }
+
+    def apply_rule(self, direction: Coord, radius: int, conditions: Sequence[Dict[str, str]]) -> int:
+        changed = self.propagate(direction, radius=radius, conditions=conditions, mutate=True)
+        if changed == 0:
+            self.fixpoint_triggered = True
+        else:
+            self.fixpoint_triggered = False
+        return changed
+
+    def state_signature(self) -> str:
+        rows = ["|".join(str(cell) for cell in row) for row in self.grid]
+        rows.append("|".join(f"{r}:{c}" for r, c in sorted(self.targets)))
+        return "#".join(rows)
+
+
+def promote_grid_rule(hypothesis: Hypothesis) -> Rule:
+    direction = tuple(hypothesis.params["direction"])
+    radius = int(hypothesis.params.get("radius", 1))
+    conditions = list(hypothesis.params.get("conditions", []))
+    priority = int(hypothesis.params.get("priority", 50))
+    name = hypothesis.params.get("name", f"track_{direction[0]}_{direction[1]}")
+
+    def applies_fn(state: GridState, context: Context) -> bool:
+        if not isinstance(state, GridState):
+            return False
+        clone = state.clone()
+        changed = clone.propagate(direction, radius=radius, conditions=conditions, mutate=True)
+        return changed > 0
+
+    def apply_fn(state: GridState, context: Context) -> GridState:
+        state.apply_rule(direction, radius, conditions)
+        return state
+
+    return Rule(
+        name=name,
+        priority=priority,
+        preconditions=[{"direction": direction, "radius": radius}],
+        effects=[{"paint": hypothesis.params.get("conditions", [])}],
+        applies_fn=applies_fn,
+        apply_fn=apply_fn,
+    )
+
+
+def make_base_rules() -> List[Rule]:
+    """Return the intentionally incomplete base rule-set."""
+
+    def r1_applies(state: GridState, context: Context) -> bool:
+        return isinstance(state, GridState) and state.clone().propagate((0, 1), mutate=True) > 0
+
+    def r1_apply(state: GridState, context: Context) -> GridState:
+        state.apply_rule((0, 1), 1, [])
+        return state
+
+    def r2_applies(state: GridState, context: Context) -> bool:
+        if not isinstance(state, GridState):
+            return False
+        if context.goal_test(state):
+            return False
+        return not state.clone().propagate((0, 1), mutate=True) > 0 and not state.fixpoint_triggered
+
+    def r2_apply(state: GridState, context: Context) -> GridState:
+        state.fixpoint_triggered = True
+        context.stuck_reason = "FIXPOINT"
+        return state
+
+    return [
+        Rule("R1_horizontal_black", priority=10, preconditions=[], effects=[], applies_fn=r1_applies, apply_fn=r1_apply),
+        Rule("R2_fixpoint", priority=90, preconditions=[], effects=[], applies_fn=r2_applies, apply_fn=r2_apply),
+    ]
+
+
+def goal_test(state: GridState) -> bool:
+    return state.progress() >= 1.0
+
+
+def build_context(grid: Grid, targets: Iterable[Coord], limits: Optional[Limits] = None) -> Tuple[Context, List[Rule]]:
+    limits = limits or build_limits()
+    seed_color: object = 0
+    if grid and isinstance(grid[0][0], str):
+        seed_color = "black"
+    state = GridState(grid=_clone_grid(grid), targets=set(targets), seed_color=seed_color)
+    context = Context(
+        state=state,
+        history=[],
+        constraints={"type": "grid_demo"},
+        goal_test=goal_test,
+        limits=limits,
+        state_hash_fn=lambda s: s.state_signature() if isinstance(s, GridState) else str(s),
+    )
+    return context, make_base_rules()
+
+
+__all__ = ["GridState", "promote_grid_rule", "make_base_rules", "build_context", "goal_test"]

--- a/puma/rft/explain.py
+++ b/puma/rft/explain.py
@@ -1,0 +1,71 @@
+"""Trace utilities to narrate the latest RFT run."""
+# [S:OBS v1] telemetry=explain_last_run pass
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .types import Context, Rule
+
+_LAST_TRACE: Dict[str, Any] | None = None
+
+
+def record_trace(
+    context: Context,
+    status: str,
+    rules: Sequence[Rule],
+    memory: Any,
+) -> None:
+    """Persist the latest execution trace for later explanation."""
+
+    global _LAST_TRACE
+    ranking_events = [
+        event
+        for event in context.history
+        if event.get("phase") == "tracking" and event.get("status") == "ranking"
+    ]
+    promotions = [
+        (event.get("rule"), event.get("score"))
+        for event in context.history
+        if event.get("phase") == "tracking" and event.get("status") == "promotion"
+    ]
+    _LAST_TRACE = {
+        "status": status,
+        "stuck_reason": context.stuck_reason,
+        "top_hypotheses": ranking_events[-1]["top"] if ranking_events else [],
+        "promotions": promotions,
+        "metrics": dict(context.metrics),
+        "rule_count": len(rules),
+    }
+
+
+def explain_last_run(context: Optional[Context] = None) -> str:
+    """Return a human readable explanation of the latest RFT execution."""
+
+    if _LAST_TRACE is None:
+        return "No RFT runs recorded yet."
+
+    trace = _LAST_TRACE.copy()
+    lines = [f"Status: {trace['status']}"]
+    if trace.get("stuck_reason"):
+        lines.append(f"Stuck reason: {trace['stuck_reason']}")
+    top = trace.get("top_hypotheses", [])
+    if top:
+        lines.append("Top hypotheses:")
+        for desc, score in top:
+            lines.append(f"  - {desc} (score={score:.2f})")
+    promotions = trace.get("promotions", [])
+    if promotions:
+        lines.append("Promoted rules:")
+        for name, score in promotions:
+            lines.append(f"  - {name} (score={score:.2f})")
+    metrics = trace.get("metrics", {})
+    if metrics:
+        metric_summary = ", ".join(f"{k}={v}" for k, v in sorted(metrics.items()))
+        lines.append(f"Metrics: {metric_summary}")
+    if context is not None and context.history:
+        lines.append(f"Events recorded: {len(context.history)}")
+    return "\n".join(lines)
+
+
+__all__ = ["record_trace", "explain_last_run"]

--- a/puma/rft/feature_flags.py
+++ b/puma/rft/feature_flags.py
@@ -1,0 +1,47 @@
+"""Feature flags and deterministic limit helpers for RFT."""
+# [S:OPER v1] feature_flag=RFT pass
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+from .types import Limits
+
+RFT_ENABLED = os.environ.get("PUMA_RFT", "0").lower() in {"1", "true", "yes"}
+RFT_DEFAULT_LIMITS: Dict[str, float | int] = {
+    "PLIANCE_STEPS": 100,
+    "TRACKING_BUDGET": 100,
+    "THRESH": 0.5,
+    "OUTER_BUDGET": 10,
+}
+
+
+def _seed_from_env() -> int:
+    seed_value = os.environ.get("PUMA_SEED")
+    if seed_value is None:
+        return 0
+    try:
+        return int(seed_value)
+    except ValueError:
+        return abs(hash(seed_value)) % (2**32)
+
+
+def build_limits(overrides: Optional[Dict[str, float | int]] = None) -> Limits:
+    """Return :class:`Limits` merged with optional overrides."""
+
+    params = dict(RFT_DEFAULT_LIMITS)
+    if overrides:
+        params.update(overrides)
+    limits = Limits(
+        pliance_steps=int(params["PLIANCE_STEPS"]),
+        tracking_budget=int(params["TRACKING_BUDGET"]),
+        thresh=float(params["THRESH"]),
+        outer_budget=int(params["OUTER_BUDGET"]),
+    )
+    # Deterministic seed for downstream contexts.
+    os.environ.setdefault("PUMA_SEED", str(_seed_from_env()))
+    return limits
+
+
+__all__ = ["RFT_ENABLED", "RFT_DEFAULT_LIMITS", "build_limits"]

--- a/puma/rft/orchestrator.py
+++ b/puma/rft/orchestrator.py
@@ -1,0 +1,139 @@
+"""Coordinator that alternates pliance and tracking phases."""
+# [S:CTRL v2] controller=rft_orchestrator pass
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Sequence, Tuple
+
+from .explain import record_trace
+from .pliance import pliance_solve
+from .tracking import HypothesisMemory, tracking_step
+from .types import Context, Rule
+
+logger = logging.getLogger("puma.rft.orchestrator")
+logger.addHandler(logging.NullHandler())
+
+
+def insert_after_stuck_rule(rules: Sequence[Rule], anchor: str | None, new_rule: Rule) -> List[Rule]:
+    """Insert ``new_rule`` immediately after the anchor that last caused a stall."""
+
+    updated = list(rules)
+    if anchor is None:
+        updated.append(new_rule)
+        logger.debug(
+            {
+                "phase": "orchestrator",
+                "event": "insert_rule",
+                "anchor": None,
+                "rule": new_rule.name,
+                "reason": "no_anchor",
+            }
+        )
+        return updated
+    for idx, rule in enumerate(updated):
+        if rule.name == anchor:
+            updated.insert(idx + 1, new_rule)
+            logger.debug(
+                {
+                    "phase": "orchestrator",
+                    "event": "insert_rule",
+                    "anchor": anchor,
+                    "rule": new_rule.name,
+                    "index": idx + 1,
+                }
+            )
+            return updated
+    updated.append(new_rule)
+    logger.debug(
+        {
+            "phase": "orchestrator",
+            "event": "insert_rule",
+            "anchor": anchor,
+            "rule": new_rule.name,
+            "reason": "anchor_not_found",
+        }
+    )
+    return updated
+
+
+def solve_with_rft(
+    context: Context,
+    rules: Sequence[Rule],
+    memory: HypothesisMemory,
+    outer_budget: int | None = None,
+) -> Tuple[Context, str]:
+    """Run pliance and tracking with adaptive promotions."""
+
+    current_rules = list(rules)
+    for promoted in memory.promoted_rules():
+        if all(existing.name != promoted.name for existing in current_rules):
+            current_rules.append(promoted)
+    if len(current_rules) > max(32, context.limits.tracking_budget * 2):
+        logger.warning(
+            {
+                "phase": "orchestrator",
+                "event": "rule_overflow",
+                "count": len(current_rules),
+            }
+        )
+    outer_budget = outer_budget or context.limits.outer_budget
+    for outer in range(outer_budget):
+        context.metric_inc("rft_outer_iterations")
+        context.record_event({"phase": "orchestrator", "outer": outer, "status": "pliance"})
+        context, status = pliance_solve(
+            context,
+            current_rules,
+            max_steps=context.limits.pliance_steps,
+        )
+        if status == "GOAL":
+            record_trace(context, status=status, rules=current_rules, memory=memory)
+            return context, "DONE"
+
+        if status not in {"PLIANCE_STUCK", "STEP_LIMIT"}:
+            context.record_event({"phase": "orchestrator", "status": status})
+            record_trace(context, status=status, rules=current_rules, memory=memory)
+            return context, status
+
+        context.record_event(
+            {
+                "phase": "orchestrator",
+                "status": "tracking",
+                "reason": context.stuck_reason,
+            }
+        )
+        new_rule = tracking_step(
+            context,
+            current_rules,
+            memory,
+            budget=context.limits.tracking_budget,
+            thresh=context.limits.thresh,
+        )
+        if new_rule is None:
+            context.record_event(
+                {
+                    "phase": "orchestrator",
+                    "status": "no_tracking_progress",
+                    "reason": context.stuck_reason,
+                }
+            )
+            record_trace(context, status="NO_TRACKING_PROGRESS", rules=current_rules, memory=memory)
+            return context, "NO_TRACKING_PROGRESS"
+
+        current_rules = insert_after_stuck_rule(current_rules, context.last_stuck_rule, new_rule)
+        context.last_rule = new_rule.name
+        context.last_stuck_rule = None
+        context.record_event(
+            {
+                "phase": "orchestrator",
+                "status": "rule_promoted",
+                "rule": new_rule.name,
+            }
+        )
+        context.metric_inc("tracking_promotions")
+
+    record_trace(context, status="OUT_OF_BUDGET", rules=current_rules, memory=memory)
+    return context, "OUT_OF_BUDGET"
+
+
+__all__ = ["solve_with_rft", "insert_after_stuck_rule"]

--- a/puma/rft/pliance.py
+++ b/puma/rft/pliance.py
@@ -1,0 +1,129 @@
+"""Deterministic pliance interpreter for rule-following behavior."""
+# [S:ALG v2] algo=pliance_inference complexity=O(steps*rules) pass
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Sequence, Tuple
+
+from .types import Context, Rule
+
+logger = logging.getLogger("puma.rft.pliance")
+logger.addHandler(logging.NullHandler())
+
+
+def _sorted_rules(rules: Sequence[Rule]) -> List[Rule]:
+    return sorted(rules, key=lambda r: (r.priority, r.name))
+
+
+def pliance_solve(
+    context: Context,
+    rules: Sequence[Rule],
+    max_steps: int | None = None,
+) -> Tuple[Context, str]:
+    """Run deterministic pliance reasoning until completion or failure."""
+
+    if max_steps is None:
+        max_steps = context.limits.pliance_steps
+
+    ordered = _sorted_rules(rules)
+    for step in range(max_steps):
+        context.metric_inc("pliance_iterations")
+        if context.mark_state_seen():
+            context.stuck_reason = "REPEAT_STATE"
+            context.last_stuck_rule = context.last_rule
+            loop_event = {
+                "phase": "pliance",
+                "step": step,
+                "status": "loop",
+                "reason": "REPEAT_STATE",
+            }
+            context.record_event(loop_event)
+            logger.debug({"phase": "pliance", "step": step, "status": "loop"})
+            return context, "PLIANCE_STUCK"
+
+        fired_this_round = False
+        if hasattr(context.state, "begin_iteration"):
+            context.state.begin_iteration(step)
+
+        for rule in ordered:
+            context.metric_inc("pliance_rules_checked")
+            should_fire = rule.applies(context)
+            logger.debug(
+                {
+                    "phase": "pliance",
+                    "step": step,
+                    "rule": rule.name,
+                    "status": "check",
+                    "should_fire": should_fire,
+                }
+            )
+            if not should_fire:
+                continue
+
+            new_state = rule.apply(context)
+            if new_state is not None:
+                context.state = new_state
+            context.last_rule = rule.name
+            fired_this_round = True
+            context.metric_inc("pliance_rule_fires")
+            event = {
+                "phase": "pliance",
+                "step": step,
+                "rule": rule.name,
+                "status": "fired",
+            }
+            context.record_event(event)
+            logger.debug(event)
+            if context.goal_test(context.state):
+                context.stuck_reason = None
+                context.last_stuck_rule = None
+                completion = {
+                    "phase": "pliance",
+                    "step": step,
+                    "rule": rule.name,
+                    "status": "goal",
+                }
+                context.record_event(completion)
+                return context, "GOAL"
+            if context.stuck_reason == "FIXPOINT" and not context.goal_test(context.state):
+                fixpoint_event = {
+                    "phase": "pliance",
+                    "step": step,
+                    "rule": rule.name,
+                    "status": "fixpoint",
+                }
+                context.record_event(fixpoint_event)
+                logger.debug(fixpoint_event)
+                return context, "PLIANCE_STUCK"
+
+        if hasattr(context.state, "end_iteration"):
+            context.state.end_iteration(step, fired_this_round)
+
+        if not fired_this_round:
+            context.stuck_reason = context.stuck_reason or "NO_RULE_APPLIED"
+            context.last_stuck_rule = context.last_rule
+            stuck_event = {
+                "phase": "pliance",
+                "step": step,
+                "status": "stuck",
+                "reason": context.stuck_reason,
+            }
+            context.record_event(stuck_event)
+            logger.debug(stuck_event)
+            return context, "PLIANCE_STUCK"
+
+    context.stuck_reason = "STEP_LIMIT"
+    context.last_stuck_rule = context.last_rule
+    limit_event = {
+        "phase": "pliance",
+        "step": max_steps,
+        "status": "limit",
+        "reason": "STEP_LIMIT",
+    }
+    context.record_event(limit_event)
+    logger.debug(limit_event)
+    return context, "STEP_LIMIT"
+
+
+__all__ = ["pliance_solve"]

--- a/puma/rft/tracking.py
+++ b/puma/rft/tracking.py
@@ -1,0 +1,221 @@
+"""Tracking module for adaptive rule discovery."""
+# [S:ALG v2] algo=tracking_search complexity=O(budget*eval_cost) pass
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+import logging
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .types import Context, Hypothesis, Rule
+
+logger = logging.getLogger("puma.rft.tracking")
+logger.addHandler(logging.NullHandler())
+
+
+@dataclass
+class HypothesisMemory:
+    """Memory of evaluated hypotheses with LRU eviction."""
+
+    cap: int = 1000
+    positives: "OrderedDict[str, Hypothesis]" = field(default_factory=OrderedDict)
+    negatives: "OrderedDict[str, Hypothesis]" = field(default_factory=OrderedDict)
+
+    def remember_positive(self, hyp: Hypothesis) -> None:
+        signature = hyp.signature()
+        self.positives[signature] = hyp
+        self.positives.move_to_end(signature)
+        while len(self.positives) > self.cap:
+            evicted_sig, _ = self.positives.popitem(last=False)
+            logger.debug({"phase": "tracking", "event": "evict_positive", "signature": evicted_sig})
+
+    def remember_negative(self, hyp: Hypothesis) -> None:
+        signature = hyp.signature()
+        self.negatives[signature] = hyp
+        self.negatives.move_to_end(signature)
+        while len(self.negatives) > self.cap:
+            evicted_sig, _ = self.negatives.popitem(last=False)
+            logger.debug({"phase": "tracking", "event": "evict_negative", "signature": evicted_sig})
+
+    def is_negative(self, hyp: Hypothesis) -> bool:
+        return hyp.signature() in self.negatives
+
+    def is_positive(self, hyp: Hypothesis) -> bool:
+        return hyp.signature() in self.positives
+
+    def promoted_rules(self) -> List[Rule]:
+        promoted: List[Rule] = []
+        for memory_rule in self.positives.values():
+            rule = getattr(memory_rule, "promoted_rule", None)
+            if isinstance(rule, Rule):
+                promoted.append(rule)
+        return promoted
+
+
+def _dedupe_hypotheses(candidates: Iterable[Hypothesis], memory: HypothesisMemory) -> List[Hypothesis]:
+    uniq: Dict[str, Hypothesis] = {}
+    for hyp in candidates:
+        sig = hyp.signature()
+        if sig in uniq:
+            continue
+        if memory.is_positive(hyp) or memory.is_negative(hyp):
+            continue
+        uniq[sig] = hyp
+    return list(uniq.values())
+
+
+def generate_variations(context: Context, base_rules: Sequence[Rule], memory: HypothesisMemory) -> List[Hypothesis]:
+    """Generate hypothesis variations by delegating to the state when available."""
+
+    candidates: List[Hypothesis] = []
+    if hasattr(context.state, "candidate_hypotheses"):
+        state_candidates = context.state.candidate_hypotheses(context, base_rules, memory)
+        candidates.extend(state_candidates)
+    else:
+        logger.debug({"phase": "tracking", "event": "no_candidate_hook"})
+    return _dedupe_hypotheses(candidates, memory)
+
+
+def evaluate_hypothesis(hypothesis: Hypothesis, context: Context) -> Tuple[float, Dict[str, object]]:
+    """Evaluate a hypothesis using an explicit progress/simplicity score.
+
+    The score adheres to the repository spec:
+
+    ``progress = satisfied_targets / total_targets`` (reported by the state)
+    ``simplicity = len(hypothesis.params.get("conditions", []))``
+    ``score = progress - 0.1 * simplicity``
+
+    The constant weight (0.1) is intentionally fixed for reproducibility and
+    discourages overly complex promoted rules.
+    """
+
+    if not hasattr(context.state, "evaluate_hypothesis"):
+        logger.debug({"phase": "tracking", "event": "no_eval_hook"})
+        return -1.0, {"reason": "no_eval_hook"}
+
+    trace = context.state.evaluate_hypothesis(hypothesis, context)
+    progress = trace.get("progress", 0.0)
+    simplicity = len(hypothesis.params.get("conditions", []))
+    score = progress - 0.1 * simplicity
+    trace.update({"simplicity": simplicity, "score": score})
+    logger.debug({
+        "phase": "tracking",
+        "event": "hypothesis_evaluated",
+        "hypothesis": hypothesis.description,
+        "score": score,
+    })
+    return score, trace
+
+
+def promote_to_rule(hypothesis: Hypothesis) -> Rule:
+    """Promote a hypothesis to an executable rule."""
+
+    promote_hook = hypothesis.params.get("promote_hook")
+    if callable(promote_hook):
+        rule = promote_hook(hypothesis)
+    elif hasattr(hypothesis, "promote_hook") and callable(getattr(hypothesis, "promote_hook")):
+        rule = hypothesis.promote_hook(hypothesis)
+    else:
+        raise ValueError(f"Hypothesis lacks promote hook: {hypothesis.description}")
+    setattr(hypothesis, "promoted_rule", rule)
+    return rule
+
+
+def tracking_step(
+    context: Context,
+    base_rules: Sequence[Rule],
+    memory: HypothesisMemory,
+    budget: int,
+    thresh: float,
+) -> Optional[Rule]:
+    """Run a single tracking step within the provided budget."""
+
+    context.metric_inc("tracking_steps")
+    candidates = generate_variations(context, base_rules, memory)
+    if not candidates:
+        logger.debug({"phase": "tracking", "event": "no_candidates"})
+        context.metrics["tracking_negatives_size"] = len(memory.negatives)
+        context.metrics["tracking_positive_cache"] = len(memory.positives)
+        return None
+
+    scored: List[Hypothesis] = []
+    for idx, hypothesis in enumerate(candidates):
+        if idx >= budget:
+            break
+        if memory.is_negative(hypothesis):
+            continue
+        score, trace = evaluate_hypothesis(hypothesis, context)
+        hypothesis.score = score
+        hypothesis.trace = trace
+        if score > 0:
+            hypothesis.evidence["pos"].append(trace)
+        else:
+            hypothesis.evidence["neg"].append(trace)
+        scored.append(hypothesis)
+        context.metric_inc("tracking_hypotheses_evaluated")
+        logger.debug({
+            "phase": "tracking",
+            "hypothesis_id": hypothesis.signature(),
+            "score": score,
+        })
+
+    if not scored:
+        context.metrics["tracking_negatives_size"] = len(memory.negatives)
+        context.metrics["tracking_positive_cache"] = len(memory.positives)
+        return None
+
+    scored.sort(key=lambda h: h.score, reverse=True)
+    top_three = scored[:3]
+    context.record_event(
+        {
+            "phase": "tracking",
+            "status": "ranking",
+            "top": [(h.description, h.score) for h in top_three],
+        }
+    )
+
+    winner = scored[0]
+    if winner.score > thresh:
+        new_rule = promote_to_rule(winner)
+        memory.remember_positive(winner)
+        context.metrics["tracking_positive_cache"] = len(memory.positives)
+        context.metrics["tracking_negatives_size"] = len(memory.negatives)
+        logger.debug({
+            "phase": "tracking",
+            "event": "promoted",
+            "hypothesis": winner.description,
+            "score": winner.score,
+        })
+        context.record_event(
+            {
+                "phase": "tracking",
+                "status": "promotion",
+                "rule": new_rule.name,
+                "score": winner.score,
+            }
+        )
+        return new_rule
+
+    for hyp in scored:
+        if hyp.score <= 0:
+            memory.remember_negative(hyp)
+            logger.debug(
+                {
+                    "phase": "tracking",
+                    "event": "negative_cache",
+                    "hypothesis": hyp.description,
+                    "score": hyp.score,
+                }
+            )
+    context.metrics["tracking_negatives_size"] = len(memory.negatives)
+    return None
+
+
+__all__ = [
+    "HypothesisMemory",
+    "generate_variations",
+    "evaluate_hypothesis",
+    "promote_to_rule",
+    "tracking_step",
+]

--- a/puma/rft/types.py
+++ b/puma/rft/types.py
@@ -1,0 +1,180 @@
+"""Typed primitives shared across the RFT modules."""
+# [S:API v2] module=types contracts=stable pass
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
+import json
+import logging
+import random
+
+logger = logging.getLogger("puma.rft.types")
+logger.addHandler(logging.NullHandler())
+
+
+@dataclass(frozen=True)
+class Entity:
+    """Structured representation of an item participating in relations."""
+
+    id: str
+    type: str
+    features: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Relation:
+    """Relational predicate over entities."""
+
+    name: str
+    arity: int
+    eval: Callable[[Sequence[Entity], "Context"], float | bool]
+
+
+@dataclass
+class Rule:
+    """Production rule evaluated by the pliance interpreter."""
+
+    name: str
+    priority: int
+    preconditions: List[Any]
+    effects: List[Any]
+    applies_fn: Callable[[Any, "Context"], bool]
+    apply_fn: Callable[[Any, "Context"], Any]
+
+    def applies(self, context: "Context") -> bool:
+        """Return ``True`` when the rule should fire for the given context."""
+
+        try:
+            result = bool(self.applies_fn(context.state, context))
+            return result
+        except Exception as exc:  # pragma: no cover - surfaced via logging
+            logger.exception("rule_applies_error", extra={"rule": self.name, "error": str(exc)})
+            return False
+
+    def apply(self, context: "Context") -> Any:
+        """Apply effects and return the next state."""
+
+        state = self.apply_fn(context.state, context)
+        return state
+
+
+@dataclass
+class Limits:
+    """Tunable bounds for the RFT control flow."""
+
+    pliance_steps: int
+    tracking_budget: int
+    thresh: float
+    outer_budget: int
+
+
+TraceEvent = Dict[str, Any]
+
+
+@dataclass
+class Context:
+    """State and execution metadata for pliance and tracking."""
+
+    state: Any
+    history: List[TraceEvent]
+    constraints: Dict[str, Any]
+    goal_test: Callable[[Any], bool]
+    limits: Limits
+    rng: random.Random = field(default_factory=random.Random)
+    metrics: MutableMapping[str, int] = field(default_factory=dict)
+    stuck_reason: Optional[str] = None
+    last_rule: Optional[str] = None
+    last_stuck_rule: Optional[str] = None
+    state_hash_fn: Optional[Callable[[Any], str]] = None
+    _seen_signatures: set[str] = field(default_factory=set, init=False, repr=False)
+
+    def record_event(self, event: TraceEvent) -> None:
+        self.history.append(event)
+        logger.debug("trace_event", extra={"event": event})
+
+    def metric_inc(self, key: str, amount: int = 1) -> None:
+        self.metrics[key] = self.metrics.get(key, 0) + amount
+
+    def state_signature(self) -> str:
+        """Return a stable hashable signature of the current state."""
+
+        if self.state_hash_fn:
+            return self.state_hash_fn(self.state)
+        try:
+            return json.dumps(self.state, sort_keys=True)
+        except TypeError:
+            return repr(self.state)
+
+    def mark_state_seen(self) -> bool:
+        """Record the current state signature and return ``True`` if seen before."""
+
+        signature = self.state_signature()
+        if signature in self._seen_signatures:
+            return True
+        self._seen_signatures.add(signature)
+        return False
+
+    def clone(self) -> "Context":
+        """Create a shallow copy of the context with duplicated history and metrics."""
+
+        cloned = Context(
+            state=self.state,
+            history=list(self.history),
+            constraints=dict(self.constraints),
+            goal_test=self.goal_test,
+            limits=self.limits,
+            rng=random.Random(self.rng.random()),
+            metrics=dict(self.metrics),
+            state_hash_fn=self.state_hash_fn,
+        )
+        cloned.stuck_reason = self.stuck_reason
+        cloned.last_rule = self.last_rule
+        cloned.last_stuck_rule = self.last_stuck_rule
+        cloned._seen_signatures = set(self._seen_signatures)
+        return cloned
+
+
+@dataclass
+class Hypothesis:
+    """Candidate adaptive rule discovered during tracking."""
+
+    description: str
+    variation_of: str
+    params: Dict[str, Any]
+    score: float = 0.0
+    evidence: Dict[str, List[Any]] = field(default_factory=lambda: {"pos": [], "neg": []})
+    trace: Dict[str, Any] | None = None
+
+    def signature(self) -> str:
+        """Deterministic identity used in the hypothesis memory."""
+
+        def _sanitize(value: Any) -> Any:
+            if callable(value):
+                return getattr(value, "__name__", repr(value))
+            if isinstance(value, dict):
+                return {k: _sanitize(v) for k, v in value.items()}
+            if isinstance(value, list):
+                sanitized = [_sanitize(v) for v in value]
+                return tuple(sorted(sanitized, key=lambda item: repr(item)))
+            if isinstance(value, tuple):
+                sanitized = tuple(_sanitize(v) for v in value)
+                return tuple(sorted(sanitized, key=lambda item: repr(item)))
+            if isinstance(value, set):
+                sanitized = [_sanitize(v) for v in value]
+                return tuple(sorted(sanitized, key=lambda item: repr(item)))
+            return value
+
+        key = {
+            "variation_of": self.variation_of,
+            "params": _sanitize(self.params),
+        }
+        return json.dumps(key, sort_keys=True)
+
+
+def ensure_iterable(obj: Any) -> Iterable[Any]:
+    """Ensure ``obj`` is iterable, turning scalars into one-length tuples."""
+
+    if isinstance(obj, (list, tuple, set)):
+        return obj
+    return (obj,)

--- a/tests/rft/test_rft_integration.py
+++ b/tests/rft/test_rft_integration.py
@@ -1,0 +1,216 @@
+"""Integration tests for the RFT pliance + tracking module."""
+# [S:TEST v2] module=rft_integration pass
+
+import importlib
+import pathlib
+import sys
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from hypothesis import given, strategies as st
+
+from puma.rft.demo.grid import build_context
+from puma.rft.feature_flags import build_limits
+from puma.rft.orchestrator import solve_with_rft, insert_after_stuck_rule
+from puma.rft.tracking import HypothesisMemory, tracking_step, evaluate_hypothesis
+from puma.rft.types import Context, Hypothesis, Rule
+from puma.rft.explain import explain_last_run
+
+
+def _build_memory() -> HypothesisMemory:
+    return HypothesisMemory(cap=16)
+
+
+def test_pliance_row_success() -> None:
+    grid = [[0, 1, 1, 1]]
+    targets = [(0, idx) for idx in range(len(grid[0]))]
+    context, rules = build_context(grid, targets)
+    memory = _build_memory()
+    context, status = solve_with_rft(context, rules, memory, outer_budget=2)
+    assert status == "DONE"
+    assert context.state.grid[0] == [0, 0, 0, 0]
+    assert context.metrics["pliance_rule_fires"] >= 1
+
+
+def test_pliance_stuck_then_tracking_vertical() -> None:
+    grid = [
+        [0, 1],
+        [2, 1],
+        [2, 1],
+    ]
+    targets = [(r, 0) for r in range(len(grid))]
+    context, rules = build_context(grid, targets)
+    memory = _build_memory()
+    context, status = solve_with_rft(context, rules, memory, outer_budget=4)
+    assert status == "DONE"
+    assert [row[0] for row in context.state.grid] == [0, 0, 0]
+    assert context.metrics.get("tracking_hypotheses_evaluated", 0) > 0
+    trace = explain_last_run(context)
+    assert "Promoted rules" in trace
+
+
+def test_reject_destructive_hypotheses() -> None:
+    grid = [[2, 2]]
+    targets = [(0, 0), (0, 1)]
+    context, rules = build_context(grid, targets)
+    memory = _build_memory()
+    bad_hypothesis = Hypothesis(
+        description="mismatched target color",
+        variation_of="R1",
+        params={
+            "direction": (0, 1),
+            "conditions": [{"target_color": 7}],
+            "promote_hook": lambda h: rules[0],
+        },
+    )
+
+    def fake_candidates(context: Context, base_rules, mem):
+        return [bad_hypothesis]
+
+    context.state.candidate_hypotheses = fake_candidates  # type: ignore[attr-defined]
+    result = tracking_step(context, rules, memory, budget=1, thresh=0.9)
+    assert result is None
+    assert bad_hypothesis.signature() in memory.negatives
+
+
+def test_hypothesis_signature_stable() -> None:
+    params_a = {"direction": (0, 1), "conditions": [{"c": 1, "d": 2}, {"d": 3, "c": 4}]}
+    params_b = {"direction": (0, 1), "conditions": [{"d": 3, "c": 4}, {"c": 1, "d": 2}]}
+    hyp_a = Hypothesis("stable signature", "R1", params=params_a)
+    hyp_b = Hypothesis("stable signature", "R1", params=params_b)
+    assert hyp_a.signature() == hyp_b.signature()
+    assert hyp_a.signature() == hyp_a.signature()
+
+
+def test_hypothesis_memory_lru_eviction() -> None:
+    memory = HypothesisMemory(cap=2)
+    hyps = [
+        Hypothesis(f"hyp-{idx}", "R1", params={"direction": (0, 1), "conditions": [], "name": f"h{idx}"})
+        for idx in range(3)
+    ]
+    for hyp in hyps:
+        memory.remember_negative(hyp)
+    assert len(memory.negatives) == 2
+    assert hyps[0].signature() not in memory.negatives
+
+
+def test_tracking_score_prefers_progress_and_simplicity() -> None:
+    class DummyState:
+        def evaluate_hypothesis(self, hypothesis: Hypothesis, context: Context) -> Dict[str, Any]:
+            return {"progress": hypothesis.params["progress"]}
+
+    context = Context(
+        state=DummyState(),
+        history=[],
+        constraints={},
+        goal_test=lambda _state: False,
+        limits=build_limits({"PLIANCE_STEPS": 4, "OUTER_BUDGET": 1, "TRACKING_BUDGET": 1}),
+    )
+    simple = Hypothesis("simple", "R1", params={"progress": 0.6, "conditions": []})
+    complex_same = Hypothesis("complex", "R1", params={"progress": 0.6, "conditions": [{"foo": 1}]})
+    advanced = Hypothesis("advanced", "R1", params={"progress": 0.8, "conditions": []})
+
+    simple_score, _ = evaluate_hypothesis(simple, context)
+    complex_score, _ = evaluate_hypothesis(complex_same, context)
+    advanced_score, _ = evaluate_hypothesis(advanced, context)
+
+    assert simple_score > complex_score
+    assert advanced_score > simple_score
+
+
+def test_insert_after_stuck_rule_positions() -> None:
+    rule_a = Rule("R1", priority=1, preconditions=[], effects=[], applies_fn=lambda s, c: False, apply_fn=lambda s, c: s)
+    rule_b = Rule("R2", priority=2, preconditions=[], effects=[], applies_fn=lambda s, c: False, apply_fn=lambda s, c: s)
+    rules: List[Rule] = [rule_a, rule_b]
+    new_rule = Rule("R_new", priority=3, preconditions=[], effects=[], applies_fn=lambda s, c: False, apply_fn=lambda s, c: s)
+    anchored = insert_after_stuck_rule(rules, "R1", new_rule)
+    assert [rule.name for rule in anchored] == ["R1", "R_new", "R2"]
+
+    appended = insert_after_stuck_rule(rules, "missing", new_rule)
+    assert appended[-1].name == "R_new"
+
+
+def test_promotion_and_reuse() -> None:
+    grid = [
+        [0, 1],
+        [2, 1],
+    ]
+    targets = [(0, 0), (1, 0)]
+    context, rules = build_context(grid, targets)
+    memory = _build_memory()
+    context, status = solve_with_rft(context, rules, memory, outer_budget=4)
+    assert status == "DONE"
+    assert memory.positives
+
+    # Reuse promoted rule on a fresh puzzle without re-search.
+    fresh_grid = [
+        [0, 1],
+        [2, 1],
+    ]
+    fresh_context, fresh_rules = build_context(fresh_grid, targets)
+    fresh_context, fresh_status = solve_with_rft(fresh_context, fresh_rules, memory, outer_budget=2)
+    assert fresh_status == "DONE"
+    assert fresh_context.metrics.get("tracking_hypotheses_evaluated", 0) == 0
+
+
+def test_solver_parity_without_metadata(monkeypatch) -> None:
+    task = {
+        "train": [
+            {"input": [[1, 0]], "output": [[1, 0]]},
+        ],
+        "test": [
+            {"input": [[1, 0]]},
+        ],
+    }
+
+    def reload_solver() -> None:
+        if "puma.rft.feature_flags" in sys.modules:
+            importlib.reload(sys.modules["puma.rft.feature_flags"])
+        if "arc_solver.solver" in sys.modules:
+            importlib.reload(sys.modules["arc_solver.solver"])
+
+    monkeypatch.setenv("PUMA_RFT", "0")
+    reload_solver()
+    from arc_solver.solver import ARCSolver as SolverBaseline  # type: ignore
+
+    baseline = SolverBaseline(use_enhancements=False).solve_task(task)
+
+    monkeypatch.setenv("PUMA_RFT", "1")
+    reload_solver()
+    from arc_solver.solver import ARCSolver as SolverRFT  # type: ignore
+
+    adaptive = SolverRFT(use_enhancements=False).solve_task(task)
+
+    assert adaptive == baseline
+
+
+def test_flag_off_does_not_change_baseline(monkeypatch) -> None:
+    monkeypatch.setenv("PUMA_RFT", "0")
+    if "arc_solver.solver" in list(sys.modules):
+        importlib.reload(sys.modules["arc_solver.solver"])
+    from arc_solver.solver import ARCSolver  # type: ignore
+
+    solver = ARCSolver(use_enhancements=False)
+    task = {
+        "train": [
+            {"input": [[1]], "output": [[2]]},
+        ],
+        "test": [
+            {"input": [[1]]},
+        ],
+    }
+    result = solver.solve_task(task)
+    assert result["attempt_1"] == [[[2]]]
+    assert result["attempt_2"] == [[[2]]]
+
+
+@given(st.integers(min_value=2, max_value=6))
+def test_property_horizontal_fill(width: int) -> None:
+    grid = [[0] + [1] * (width - 1)]
+    targets = [(0, idx) for idx in range(width)]
+    context, rules = build_context(grid, targets)
+    memory = _build_memory()
+    context, status = solve_with_rft(context, rules, memory, outer_budget=2)
+    assert status == "DONE"
+    assert all(value == 0 for value in context.state.grid[0])


### PR DESCRIPTION
## Summary
- tune the RFT context/pliance/orchestrator flow to track the last stuck rule, guard repeat states, and insert promoted rules deterministically with metrics
- document the explicit progress-minus-simplicity scoring rule, add an executable promotion demo, and expose the new insertion helper through the package API
- expand the RFT test suite with signature/LRU/scoring checks plus ARC solver parity validation when the feature flag is disabled or metadata is absent

## Testing
- pytest tests/rft/test_rft_integration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d0e8702ca48322b333a7810d5045e2